### PR TITLE
chore: allow PHP_CodeSniffer 4.x in composer dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,4 @@ jobs:
         uses: minvws/action-sonarqube@v1
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
+          allow-run-on-dependabot: 'true'

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpunit/phpunit": "^10.2",
         "slevomat/coding-standard": "^8.14",
         "spatie/phpunit-snapshot-assertions": "^5.1",
-        "squizlabs/php_codesniffer": "^3.8",
+        "squizlabs/php_codesniffer": "^3.8 | ^4.0",
         "symfony/var-dumper": "^6.0 | ^7.0"
     },
     "autoload": {


### PR DESCRIPTION
Allow PHP_CodeSniffer 4.x in composer dependencies, fixes this issue: https://github.com/minvws/nl-rdo-php-audit-logger/pull/21